### PR TITLE
Fix signature

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ufcg-lsd/arrebol-pb-worker/utils"
 	"github.com/ufcg-lsd/arrebol-pb-worker/worker"
 	"log"
+	"net/http"
 	"os"
 )
 
@@ -24,9 +25,10 @@ func sendKey(serverEndPoint string, workerId string) {
 	log.Println("Sending pub key to the server. ServerEndpoint: " + serverEndPoint)
 	url := serverEndPoint + "/workers/publicKey"
 	requestBody := &map[string]*rsa.PublicKey{"key": utils.GetPublicKey(workerId)}
-	httpResp := utils.Post(requestBody, url)
+	httpResp, err := utils.Post(workerId, requestBody, http.Header{}, url)
 
-	if httpResp.StatusCode != 201 {
+
+	if httpResp.StatusCode != 201 || err != nil {
 		log.Fatal("Unable to send public key to the server")
 	}
 }

--- a/utils/http_utils.go
+++ b/utils/http_utils.go
@@ -12,6 +12,10 @@ type HTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+const (
+	SIGNATURE_KEY_PATTERN = "SIGNATURE"
+)
+
 var (
 	Client HTTPClient = &http.Client{}
 	GetSignature func(payload interface{}, workerId string) []byte = getSignature
@@ -30,14 +34,14 @@ func getSignature(payload interface{}, workerId string) []byte {
 		log.Fatal("Error on marshalling the payload")
 	}
 
-	signedPayload, _ := SignMessage(GetPrivateKey(workerId), parsedPayload)
+	signature, _ := SignMessage(GetPrivateKey(workerId), parsedPayload)
 
-	return signedPayload
+	return signature
 }
 
 func AddSignature(workerId string, payload interface{}, headers http.Header) http.Header {
 	signature := GetSignature(payload, workerId)
-	headers.Set("SIGNATURE", string(signature))
+	headers.Set(SIGNATURE_KEY_PATTERN, string(signature))
 	return headers
 }
 

--- a/utils/http_utils.go
+++ b/utils/http_utils.go
@@ -14,6 +14,7 @@ type HTTPClient interface {
 
 var (
 	Client HTTPClient = &http.Client{}
+	GetSignature func(payload interface{}, workerId string) []byte = getSignature
 )
 
 type HttpResponse struct {
@@ -22,22 +23,27 @@ type HttpResponse struct {
 	StatusCode int
 }
 
-// It send an http post to the endpoint signing the body with the worker's private key
-func SignedPost(workerId string, body interface{}, endpoint string) *HttpResponse{
-	requestBody, err := json.Marshal(body)
+func getSignature(payload interface{}, workerId string) []byte {
+	parsedPayload, err := json.Marshal(payload)
 
 	if err != nil {
-		log.Fatal("Error on marshalling the request body")
+		log.Fatal("Error on marshalling the payload")
 	}
 
-	data, hashSum := SignMessage(GetPrivateKey(workerId), requestBody)
+	signedPayload, _ := SignMessage(GetPrivateKey(workerId), parsedPayload)
 
-	payload := &map[string][]byte{"data": data, "hashSum": hashSum}
-
-	return Post(payload, endpoint)
+	return signedPayload
 }
 
-func Post(body interface{}, endpoint string) *HttpResponse{
+func AddSignature(workerId string, payload interface{}, headers http.Header) http.Header {
+	signature := GetSignature(payload, workerId)
+	headers.Set("SIGNATURE", string(signature))
+	return headers
+}
+
+func Post(workerId string, body interface{}, headers http.Header, endpoint string) (*HttpResponse, error){
+	headers = AddSignature(workerId, body, headers)
+
 	requestBody, err := json.Marshal(body)
 
 	if err != nil {
@@ -45,29 +51,31 @@ func Post(body interface{}, endpoint string) *HttpResponse{
 	}
 
 	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewBuffer(requestBody))
-
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
+
+	req.Header = headers
 
 	resp, err := Client.Do(req)
 
 	if err != nil {
-		log.Fatal("Unable to reach the server on endpoint: " + endpoint)
-		panic(err)
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	respBody, err := ioutil.ReadAll(resp.Body)
 
 	if err != nil {
-		log.Fatal("Error on parsing the body to byte")
+		return nil, err
 	}
 
-	return &HttpResponse{Body: respBody, Headers: resp.Header, StatusCode: resp.StatusCode}
+	return &HttpResponse{Body: respBody, Headers: resp.Header, StatusCode: resp.StatusCode}, nil
 }
 
-func Get(endpoint string, header http.Header) (*HttpResponse, error){
+func Get(workerId string, endpoint string, header http.Header) (*HttpResponse, error){
+	header = AddSignature(workerId, endpoint, header)
+
 	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
 
 	if err != nil {

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -9,6 +9,10 @@ import (
 	"net/http"
 )
 
+const (
+	PUBLIC_KEY = "PUBLIC-KEY"
+)
+
 //It represents each one of the worker's instances that will run on the worker node.
 //The informations kept in this struct are important to the
 //communication process with the server. While the Vcpu and Ram allow the server
@@ -40,7 +44,6 @@ const (
 	TaskFailed
 )
 
-
 //This struct represents a task, the executable piece of the system.
 type Task struct {
 	// Sequence of unix command to be execute by the worker
@@ -68,8 +71,8 @@ func (w *Worker) Join(serverEndpoint string) {
 		log.Fatal("error on marshalling public key")
 	}
 
-	headers.Set("PUBLIC-KEY", string(parsedKey))
-	httpResponse, err := utils.Post(w.Id, w, http.Header{}, serverEndpoint + "/workers")
+	headers.Set(PUBLIC_KEY, string(parsedKey))
+	httpResponse, err := utils.Post(w.Id, w, headers, serverEndpoint + "/workers")
 
 	if err != nil {
 		log.Fatal("Error on joining the server: " + err.Error())

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -60,7 +60,21 @@ func (ts TaskState) String() string {
 }
 
 func (w *Worker) Join(serverEndpoint string) {
-	httpResponse := utils.SignedPost(w.Id, w, serverEndpoint + "/workers")
+	headers := http.Header{}
+	publicKey := utils.GetPublicKey(w.Id)
+	parsedKey, err := json.Marshal(publicKey)
+
+	if err != nil {
+		log.Fatal("error on marshalling public key")
+	}
+
+	headers.Set("PUBLIC-KEY", string(parsedKey))
+	httpResponse, err := utils.Post(w.Id, w, http.Header{}, serverEndpoint + "/workers")
+
+	if err != nil {
+		log.Fatal("Error on joining the server: " + err.Error())
+	}
+
 	HandleJoinResponse(httpResponse, w)
 }
 
@@ -104,7 +118,7 @@ func (w *Worker) GetTask(serverEndPoint string) (*Task, error) {
 	headers := http.Header{}
 	headers.Set("arrebol-worker-token", w.Token)
 
-	httpResp, err := utils.Get(url, headers)
+	httpResp, err := utils.Get(w.Id, url, headers)
 
 	if err != nil {
 		return nil, errors.New("Error on GET request: " + err.Error())

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -89,6 +89,11 @@ func TestWorker_GetTask(t *testing.T) {
 
 	utils.Client = &MockedClient{}
 
+	utils.GetSignature = func(payload interface{}, workerId string) []byte {
+		fakeSignature, _ := json.Marshal("FAKE-SIGNATURE")
+		return fakeSignature
+	}
+
 	//exercise
 	mockedTask, err := workerTestInstance.GetTask("http://test-server:8000/v1")
 


### PR DESCRIPTION
The signature was being sent in the request's body, but it must go in the header.